### PR TITLE
Fixes for several errors

### DIFF
--- a/src/bgipc.xml
+++ b/src/bgipc.xml
@@ -2279,7 +2279,7 @@ described in the <link dest="mqftok">Message Queues section</link>.)</p>
 
 <p>The next argument, <param>nsems</param>, is (you guessed it!) the
 number of semaphores in this semaphore set.  The maximum number is system
-dependent, but it's probably between 500 and 2000.  If you're needing
+dependent, but it's probably around 32000.  If you're needing
 more (greedy wretch!), just get another semaphore set.</p>
 
 <p>Finally, there's the <param>semflg</param> argument.  This tells

--- a/src/bgipc.xml
+++ b/src/bgipc.xml
@@ -2498,7 +2498,7 @@ put <const>1</const> as this argument.</p>
 
 <p>One field in the <nobr><type>struct sembuf</type></nobr> that I
 haven't mentioned is the <var>sem_flg</var> field which allows the
-program to specify flags the further modify the effects of the
+program to specify flags to further modify the effects of the
 <func>semop()</func> call.</p>
 
 <p>One of these flags is <const>IPC_NOWAIT</const> which, as the name

--- a/src/bgipc.xml
+++ b/src/bgipc.xml
@@ -1377,7 +1377,7 @@ readers, anyway?</p>
 The way to do this is to call <func>open()</func> with the
 <const>O_NDELAY</const> flag set in the mode argument:</p>
 
-<code>fd = open(FIFO_NAME, O_RDONLY | <b>O_NDELAY</b>);</code>
+<code>fd = open(FIFO_NAME, O_WRONLY | <b>O_NDELAY</b>);</code>
 
 <p>This will cause <func>open()</func> to return <const>-1</const> if
 there are no processes that have the file open for reading.</p>

--- a/src/bgipc.xml
+++ b/src/bgipc.xml
@@ -2278,7 +2278,7 @@ by different processes to identify this semaphore set.  (This
 described in the <link dest="mqftok">Message Queues section</link>.)</p>
 
 <p>The next argument, <param>nsems</param>, is (you guessed it!) the
-number of semaphores in this semaphore set.  The exact number is system
+number of semaphores in this semaphore set.  The maximum number is system
 dependent, but it's probably between 500 and 2000.  If you're needing
 more (greedy wretch!), just get another semaphore set.</p>
 

--- a/src/bgipc.xml
+++ b/src/bgipc.xml
@@ -3253,8 +3253,7 @@ int main(int argc, char *argv[])
 		exit(1);
 	}
 	
-	data = mmap((caddr_t)0, sbuf.st_size, PROT_READ, MAP_SHARED, fd, 0)) \
-	                                                       == (caddr_t)(-1)) {
+	data = mmap((caddr_t)0, sbuf.st_size, PROT_READ, MAP_SHARED, fd, 0);
 	if (data == (caddr_t)(-1)) {
 		perror("mmap");
 		exit(1);


### PR DESCRIPTION
Fixed several easy to spot errors on the guide as I noticed them while reading it and thought I'd fix them to improve the overall quality of the guide.

Detailed explanation of each one of the fixes:
Note: All references to the page numbers in the pdf refer to http://beej.us/guide/bgipc/pdf/bgipc_USLetter.pdf.

In the section "5.3. O_NDELAY! I'm UNSTOPPABLE!" located in page 17th(21th)
there's the following one line code-snippet
fd = open(FIFO_NAME, O_RDONLY | O_NDELAY);
which opens the file for reading, but this directly collides with the next
line: "This will cause open() to return -1 if there are no processes
that have the file open for reading.". I believe that's the error one
would get if one was opening the file in write mode, as is specified in
the official documentation[1]. Further support for this thesis is found
in the next line: "Likewise, you can open the reader process...". Based
on these 2 points of evidence it seems clear that it's actually a typo
and you meant to write:
fd = open(FIFO_NAME, O_WRONLY | O_NDELAY);


In section "8.1. Grabbing some semaphores", page 28 (32) there's a
definition of the parameter nsems of the function semget which seems to
have a typo:
"The next argument, nsems, is (you guessed it!) the number of
semaphores in this semaphore set. The exact number is system dependent,
but it's probably between 500 and 2000. If you're needing more (greedy
wretch!), just get another semaphore set."
My hypothesis is that you meant to use the word "maximum" instead of
"exact" as in the way it currently stands it's simply not coherent:
1. nsems is a parameter set by the programmer but you say it's
an exact number set by the system.
2. The comment about being greedy in case of needing more makes
perfect sense if we were talking about the maximum number but it
doesn't if it's about the exact number.
3. The 500-2000 number fits the system V documentation from
2007[2], which states the the default number for the maximum amount of
semaphores per identifier is 2048. The key point is that in the guides
webpage you state that the guide was written about 10 years ago[3], a
date that just first perfectly with the year in which the documentation
was written.

Sidenote: Since the guide was written, the maximum number of semaphores
has been updated and currently it is 32000 in my Fedora machine (I
looked it up using "cat /proc/sys/kernel/sem", it's the first number
from the left[4]), to avoid having to keep updating it, you could simply say
that the maximum number is equal to the constant SEMMSL[5]. Still, my
preferred way would be to just give users the command "cat
/proc/sys/kernel/sem | sed 's/\t.*//'" and tell them to check it
themselves, that way they'll have the tools to know the exact number
for the system they're working on. But I do understand that the purpose of this guide is to be simple an approachable and not just become another manpage, so I've followed your style and just simply updated the number, in case you'd rather keep the old number you just have to revert the last commit.


In section "8.3. semop(): Atomic power!" on page 30 (34) there's a
simple typo in the phrase "One field in the struct sembuf that I
haven't mentioned is the sem_flg field which allows the
program to specify flags the further modify the effects of the semop()
call.", the fourth "the" should be a "to".


Finally, in the section "10.4. A simple sample", page 41 (45), there's
a part of the code that seems to be uncomplete:
data = mmap((caddr_t)0, sbuf.st_size, PROT_READ, MAP_SHARED,
fd, 0)) \
== (caddr_t)(-1)) {
In my opinion, what happened is that you first tried to do the
function's execution and checking together but then decided against it
(as right after that line there's an " if" that checks that there hasn't
been an error) but you simply forgot to remove that part of code at the
end.
Cleaning it up, it would be:
data = mmap((caddr_t)0, sbuf.st_size, PROT_READ, MAP_SHARED,
fd, 0));


[1]"If O_NDELAY or O_NONBLOCK is set: An open for reading-only will
return without delay; an open for writing-only will return an error if
no process currently has the file open for reading." - manpage of open
(http://uw714doc.sco.com/en/man/html.2/open.2.html (22/8/2017)
[2] https://docstore.mik.ua/manuals/hp-ux/en/B2355-60130/semmsl.5.html
[3] "About ten years ago, I wrote a small guide to Unix Interprocess
Communication (IPC)." - http://beej.us/guide/bgipc/ (22/8/2017)
[4] https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Li
nux/5/html/Tuning_and_Optimizing_Red_Hat_Enterprise_Linux_for_Oracle_9i
_and_10g_Databases/sect-Oracle_9i_and_10g_Tuning_Guide-
Setting_Semaphores-Setting_Semaphore_Parameters.html (23/8/2017)
[5] "the maximum number of semaphores per semaphore set (SEMMSL)." -
semget's manpage (http://man7.org/linux/man-pages/man2/semget.2.html
(23/8/2017))