### PR TITLE
Fix user-defined signal 2 typo in Section 3

### DIFF
--- a/attic/orightml/signals.html
+++ b/attic/orightml/signals.html
@@ -51,7 +51,7 @@ to destroy the process.)
 <p>
 Are all the signals predefined?  What if you want to send a signal that
 has significance that only you understand to a process?  There are two
-signals that aren't reserved: <tt>SIGUSR1</tt> and <tt>SIGUSER2</tt>.
+signals that aren't reserved: <tt>SIGUSR1</tt> and <tt>SIGUSR2</tt>.
 You are free to use these for whatever you want and handle them in
 whatever way you choose.  (For example, my cd player program might
 respond to <tt>SIGUSR1</tt> by advancing to the next track.  In this

--- a/src/bgipc.xml
+++ b/src/bgipc.xml
@@ -567,7 +567,7 @@ destroy the process.)</p>
 <p>Are all the signals predefined?  What if you want to send a signal
 that has significance that only you understand to a process?  There are
 two signals that aren't reserved: <const>SIGUSR1</const> and
-<const>SIGUSER2</const>.  You are free to use these for whatever you
+<const>SIGUSR2</const>.  You are free to use these for whatever you
 want and handle them in whatever way you choose.  (For example, my cd
 player program might respond to <const>SIGUSR1</const> by advancing to
 the next track.  In this way, I could control it from the command line


### PR DESCRIPTION
Fixes typo in Section 3.
SIGUSER2 -> SIGUSR2
Reference: https://man7.org/linux/man-pages/man7/signal.7.html

Thanks a lot for the Guide, it was very helpful for my studies.