### PR TITLE
Balance square brackets, fix duplicating section 4.2 bug

### DIFF
--- a/src/bgipc_part_0400_pipes.md
+++ b/src/bgipc_part_0400_pipes.md
@@ -43,7 +43,7 @@ written to the pipe, and read from the other end in the order it came
 in. On many systems, pipes will fill up after you write about 10K to
 them without reading anything out.
 
-As a [flx[useless example|pipe1.c], the following program creates,
+As a [flx[useless example|pipe1.c]], the following program creates,
 writes to, and reads from a pipe.
 
 ``` {.c .numberLines}


### PR DESCRIPTION
On the beej.us site, there is a rendering bug around section 4.2 (it duplicates the entire section except the code snippet, see screen shot below).
https://beej.us/guide/bgipc/html/split/pipes.html#the-search-for-pipe-as-we-know-it

See #12 for more details
